### PR TITLE
Added php-mongo and php-redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get update \
  php5.6-zip \
  php-imagick \
  php-xdebug \
+ php-mongo \
+ php-redis \
  nodejs \
  yarn \
  ant \


### PR DESCRIPTION
Both extensions are needed for the cache packages tests (only the extensions, not the actual systems behind them)